### PR TITLE
Feat(browserslist-config): Introduce Browserslist config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # Code Quality Tools
 
-> Build with ❤️ at [LMC][lmc-home]
+> Built with ❤️ at [LMC][lmc-home]
 
 This monorepo contains shareable configurations for various coding-style/best practices/lint tools to make the configurations consistent across projects and provide easy setup mechanism.
 
-## Available configurations
+## Available Configurations
 
-| Tool                   | Package                                                                                       | Version                                                                           | Description                              |
-| ---------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------- |
-| Conventional Changelog | [@lmc-eu/conventional-changelog-lmc-bitbucket](packages/conventional-changelog-lmc-bitbucket) | [![@lmc-eu/conventional-changelog-lmc-bitbucket][cc-badge]][cc-npm]               | Configuration for Conventional Changelog |
-| Prettir Config | [@lmc-eu/prettier-config](packages/prettier-config) | [![@lmc-eu/prettier-config][pc-badge]][pc-npm]               | Configuration for Prettier |
-| Commitlint | [@lmc-eu/commitlint-config](packages/commitlint-config) | [![@lmc-eu/commitlint-config][clc-badge]][clc-npm]               | Configuration for Commitlint |
-| Stylelint | [@lmc-eu/stylelint-config](packages/stylelint-config) | [![@lmc-eu/stylelint-config][slc-badge]][slc-npm]               | Configuration for Stylelint |
+| Tool                   | Package                                                                                       | Version                                                                    |
+| ---------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Browserslist           | [@lmc-eu/browserslist-config](packages/browserslist-config)                                   | [![@lmc-eu/browserslist-config][blc-badge]][blc-npm]                       |
+| Commitlint             | [@lmc-eu/commitlint-config](packages/commitlint-config)                                       | [![@lmc-eu/commitlint-config][clc-badge]][clc-npm]                         |
+| Conventional Changelog | [@lmc-eu/conventional-changelog-lmc-bitbucket](packages/conventional-changelog-lmc-bitbucket) | [![@lmc-eu/conventional-changelog-lmc-bitbucket][cc-badge]][cc-npm]        |
+| Prettier               | [@lmc-eu/prettier-config](packages/prettier-config)                                           | [![@lmc-eu/prettier-config][pc-badge]][pc-npm]                             |
+| Stylelint              | [@lmc-eu/stylelint-config](packages/stylelint-config)                                         | [![@lmc-eu/stylelint-config][slc-badge]][slc-npm]                          |
 
 [lmc-home]: https://www.lmc.eu
+[blc-npm]: https://npmjs.org/package/%40lmc-eu/browserslist-config
+[blc-badge]: https://img.shields.io/npm/v/%40lmc-eu/browserslist-config.svg?style=flat-square
 [cc-npm]: https://npmjs.org/package/%40lmc-eu/conventional-changelog-lmc-bitbucket
 [cc-badge]: https://img.shields.io/npm/v/%40lmc-eu/conventional-changelog-lmc-bitbucket.svg?style=flat-square
 [pc-npm]: https://www.npmjs.com/package/@lmc-eu/prettier-config

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,10 +6,11 @@ module.exports = {
   ],
   rules: {
     'scope-enum': [1, 'always', [
+      'browserslist',
       'commitlint',
+      'conventional-changelog',
       'prettier',
       'stylelint',
-      'conventional-changelog'
     ]],
 
     'footer-max-line-length': [0],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "code-quality-tools",
   "version": "1.0.0",
   "description": "Monorepo aggregating various packages, generators, scripts and other goodies to make code look/work better",
-  "repository": "ssh://git@bitbucket.lmc.cz:7999/js/code-quality-tools.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lmc-eu/code-quality-tools"
+  },
   "author": "Tomáš Litera <tomas.litera@lmc.eu>",
   "license": "MIT",
   "private": true,

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,0 +1,87 @@
+# `@lmc-eu/browserslist-config`
+
+> LMC's config for Browserslist
+
+## Installation
+
+```bash
+# Yarn:
+yarn add --dev @lmc-eu/browserslist-config
+
+# npm:
+npm install --save-dev @lmc-eu/browserslist-config
+```
+
+## Usage
+
+Add this to `.browserslistrc` file:
+
+```
+extends @lmc-eu/browserslist-config
+```
+
+Alternatively, add this to your `package.json` file:
+
+```json
+"browserslist": [
+  "extends @lmc-eu/browserslist-config"
+]
+```
+
+### Extending
+
+If you need to support IE (or any other browser):
+
+```
+extends @lmc-eu/browserslist-config
+
+ie # sorry!
+```
+
+### Using Real-World Statistics
+
+You may provide your own browser statistics.
+
+To get the data from Google Analytics, use one of the following tools:
+
+- [browserslist-ga-export](https://github.com/browserslist/browserslist-ga-export)
+  — create a custom report in GA and export it to CSV,
+- [browserslist-ga](https://github.com/browserslist/browserslist-ga)
+  — easier if you are OK with providing your Google password to a third-party tool.
+
+Make the resulting file available to Browserslist by saving it right next to
+your `.browserslistrc` (or `package.json`, wherever you store your config):
+
+```
+# Project root
+
+- .browserslistrc
+- browserslist-stats.json
+- package.json
+- …
+```
+
+Refer to the stats file in your Browserslist configuration:
+
+```
+extends @lmc-eu/browserslist-config
+
+> 0.5% in my stats
+```
+
+For more configuration examples including Autoprefixer, Babel, ESLint, PostCSS,
+and Stylelint see [Browserslist examples][browserslist-examples].
+
+### Checking Results
+
+Anytime you can run `npx browserslist` in your project root to see what
+browsers are actually matched against your configuration.
+
+## Updating Browsers Database
+
+You should run `npx browserslist@latest --update-db` [every few months][updates]
+to update the `caniuse` database in the background, so you always develop for
+current browsers.
+
+[browserslist-examples]: https://github.com/browserslist/browserslist-example#browserslist-example
+[updates]: https://github.com/browserslist/browserslist/issues/492

--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -1,0 +1,17 @@
+module.exports = [
+  // Blink/Chromium based
+  'last 1 Android versions',
+  'last 1 ChromeAndroid versions',
+  'last 2 Chrome versions',
+  'last 2 Edge versions',
+  'last 2 Opera versions',
+  'last 1 Samsung versions',
+
+  // Gecko based
+  'last 1 FirefoxAndroid versions',
+  'last 2 Firefox versions',
+
+  // WebKit based
+  'last 2 iOS major versions',
+  'last 2 Safari major versions',
+];

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@lmc-eu/browserslist-config",
+  "version": "1.0.0",
+  "description": "LMC's config for Browserslist",
+  "keywords": [
+    "browserslist",
+    "browserslist-config",
+    "lmc"
+  ],
+  "author": "Adam Kudrna <adam.kudrna@lmc.eu>",
+  "license": "MIT",
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lmc-eu/code-quality-tools",
+    "directory": "packages/browserslist-config"
+  },
+  "engines": {
+    "node": ">=10"
+  }
+}

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -11,7 +11,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "ssh://git@bitbucket.lmc.cz:7999/js/code-quality-tools.git"
+    "url": "https://github.com/lmc-eu/code-quality-tools",
+    "directory": "packages/commitlint-config"
   },
   "main": "index.js",
   "publishConfig": {

--- a/packages/conventional-changelog-lmc-bitbucket/package.json
+++ b/packages/conventional-changelog-lmc-bitbucket/package.json
@@ -9,7 +9,10 @@
     "conventional-changelog",
     "preset"
   ],
-  "repository": "ssh://git@bitbucket.lmc.cz:7999/js/conventional-changelog-lmc-bitbucket.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lmc-eu/conventional-changelog-lmc-bitbucket"
+  },
   "author": "Tomáš Litera <tomas.litera@lmc.eu>",
   "license": "MIT",
   "bugs": {

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@bitbucket.lmc.cz:7999/js/code-quality-tools.git"
+    "url": "https://github.com/lmc-eu/code-quality-tools",
+    "directory": "prettier-config"
   },
   "engines": {
     "node": ">=10"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@bitbucket.lmc.cz:7999/js/code-quality-tools.git"
+    "url": "https://github.com/lmc-eu/code-quality-tools",
+    "directory": "stylelint-config"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
- Based on commonly used browsers in CZ (`npx browserslist '> 0.5% in CZ'`).
- IE not included, but…
- … developers can add it (or any other browser) later in their config.
