### PR TITLE
Consider increasing printWidth to 100 characters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-max_line_length = 100
+max_line_length = 120
 
 [{Makefile,makefile,**.mk}]
 indent_style = tab

--- a/packages/prettier-config/index.js
+++ b/packages/prettier-config/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   singleQuote: true,
   bracketSpacing: true,
+  printWidth: 100,
   semi: true,
   trailingComma: "all",
 }


### PR DESCRIPTION
Hi,
I'd like to propose increasing the default 80 characters defined for Prettier's `printWidth`. 

I read the reasoning in [Prettier documentation](https://prettier.io/docs/en/options.html#print-width), but I don't think its actually a good decision.

While working on [cookie-consent-manager](https://github.com/lmc-eu/cookie-consent-manager/), I came across several situations, where the line wraping done by prettier was actually making the code harder to read. 

For example:

```diff
      window.dataLayer.push({
        'CookieConsent.necessary': cookie.level.includes('necessary'),
        'CookieConsent.analytics': cookie.level.includes('analytics'),
        'CookieConsent.functionality': cookie.level.includes('functionality'),
-        'CookieConsent.personalization': cookie.level.includes('personalization'),
+        'CookieConsent.personalization':
+          cookie.level.includes('personalization'),
        'CookieConsent.revision': cookie.revision,
      });
```

The line length would be 83 characters (so prettier still may not break it, as per docs) and yet it is broken up. Having lines a bit above 80 characters is also not something unusual when using descriptive variable names. Even in small project like [cookie-consent-manager](https://github.com/lmc-eu/cookie-consent-manager/) there are multiple places where this line breaking is (for me) quite unexpected and does not in my opinion improve code readability.

Also many people uses line limits set to something like 120 characters, which is IMO quite reasonable on today wide-screen monitors.

So I'm proposing 100 character compromise for prettier (and 120 chars hard limit in `.editorconfig`). This line length is in my experience OK even for side-by-side diffs. And is enough for all the "edge cases" I came across.

What do you mean?

Or is there some other way how to configure prettier to not break lines like the one above?