### PR TITLE
Stylelint: Prefer double-colon notation for pseudo elements as required by CSS spec

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -28,7 +28,7 @@ module.exports = {
     'declaration-block-no-shorthand-property-overrides': true,
     'selector-pseudo-class-no-unknown': true,
     'selector-pseudo-element-no-unknown': true,
-    'selector-pseudo-element-colon-notation': 'single',
+    'selector-pseudo-element-colon-notation': 'double',
     'selector-type-no-unknown': true,
     'selector-max-class': 5,
     'selector-max-empty-lines': 0,


### PR DESCRIPTION
Stylelint currently requires single colon:

```css
.box:before,
.box:after {
    /* … */
}
```

But double colon is correct:

```css
.box::before,
.box::after {
    /* … */
}
```

The reason is that starting from CSS 3, [all pseudo elements must use double colon](https://css-tricks.com/to-double-colon-or-not-do-double-colon/). Single colon is supported by browsers just for backward compatibility reason.