### PR TITLE
Feat(eslint-config-base): Ignore extraneous dependencies for prettier config

### DIFF
--- a/packages/eslint-config-base/rules/imports.js
+++ b/packages/eslint-config-base/rules/imports.js
@@ -53,6 +53,7 @@ module.exports = {
           '**/protractor.conf.*.js', // protractor config
           '**/karma.conf.js', // karma config
           '**/.eslintrc.js', // eslint config
+          '**/.prettierrc.js', // prettier config
           '**/postcss.config.js', // postcss config
         ],
         optionalDependencies: false,


### PR DESCRIPTION
See https://github.com/lmc-eu/spirit-design-system/pull/93 where require in `.prettierrc.js` must be ignored.
