### PR TITLE
BREAKING CHANGES(conventional-changelog): Switch from asterisk to hyphen #refs 48

### DIFF
--- a/packages/conventional-changelog-lmc-bitbucket/src/templates/commit.hbs
+++ b/packages/conventional-changelog-lmc-bitbucket/src/templates/commit.hbs
@@ -1,5 +1,5 @@
 
-*{{#if scope}} **{{scope}}:**
+-{{#if scope}} **{{scope}}:**
 {{~/if}} {{#if subject}}
   {{~subject}}
 {{~else}}

--- a/packages/conventional-changelog-lmc-bitbucket/src/templates/footer.hbs
+++ b/packages/conventional-changelog-lmc-bitbucket/src/templates/footer.hbs
@@ -4,7 +4,7 @@
     ### {{title}}
 
     {{#each notes}}
-      * {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}
+      - {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}
     {{/each}}
   {{/each}}
 

--- a/packages/conventional-changelog-lmc-github/src/templates/commit.hbs
+++ b/packages/conventional-changelog-lmc-github/src/templates/commit.hbs
@@ -1,4 +1,4 @@
-*{{#if scope}} **{{scope}}:**
+-{{#if scope}} **{{scope}}:**
 {{~/if}} {{#if subject}}
   {{~subject}}
 {{~else}}

--- a/packages/conventional-changelog-lmc-github/src/templates/footer.hbs
+++ b/packages/conventional-changelog-lmc-github/src/templates/footer.hbs
@@ -4,7 +4,7 @@
     ### {{title}}
 
     {{#each notes}}
-      * {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}
+      - {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}
     {{/each}}
   {{/each}}
 


### PR DESCRIPTION
  * in unordered lists only
  * for compatibility with prettier formatting
  * also hyphen is is most used symbol for unordered lists
  * @see: https://github.com/prettier/prettier/issues/4251