### PR TITLE
Feat(stylelint-config): Set camelCaseSvgKeywords to true

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -80,6 +80,7 @@ module.exports = {
       'lower',
       {
         ignoreProperties: ['$font-family-base'],
+        camelCaseSvgKeywords: true,
       },
     ],
     'at-rule-name-case': 'lower',

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -26,6 +26,6 @@
     "stylelint-order": "^4.1.0"
   },
   "peerDependencies": {
-    "stylelint": "^14.2.0"
+    "stylelint": "^14.3.0"
   }
 }


### PR DESCRIPTION
added [camelCaseSvgKeywords rule](https://stylelint.io/user-guide/rules/list/value-keyword-case/#camelcasesvgkeywords-true--false-default-false) for correct resolution `color: currentColor` (from stylelint 14.3.0). Problem mapped in https://github.com/stylelint/stylelint/pull/5849