### PR TITLE
Chore(repo): Run prettier before releasing new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "format:check": "prettier --check ./",
     "format:fix": "prettier --write ./",
     "lint": "eslint ./",
-    "lint:fix": "yarn lint --fix"
+    "lint:fix": "yarn lint --fix",
+    "version": "yarn format:fix"
   },
   "devDependencies": {
     "commitlint-cli": "^1.1.3",


### PR DESCRIPTION
  * lerna adds more blank lines than necessary between version in
    changelog
  * @see https://github.com/lerna/lerna/tree/main/commands/version#lifecycle-scripts