### PR TITLE
BREAKING CHANGES(stylelint): Remove `camelCaseSvgKeywords` in `value-…

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -80,7 +80,6 @@ module.exports = {
       'lower',
       {
         ignoreProperties: ['$font-family-base'],
-        camelCaseSvgKeywords: true,
       },
     ],
     'at-rule-name-case': 'lower',


### PR DESCRIPTION
…keyword-case`

  * this options requires svg keywords to be in camel case like
    `currentColor`
  * this casing is considered as legacy by community and shoudl be
    avoided

- @see: https://github.com/stylelint/stylelint/releases/tag/14.3.0
- https://github.com/lmc-eu/code-quality-tools/commit/37f8331

Fixes:
- https://github.com/lmc-eu/cookie-consent-manager/commit/72dd62494aa2980835c99ced17aa653b80502aec
- https://github.com/lmc-eu/cookie-consent-manager/commit/df8be8d334c5d9479ef1eb958752451e950c4ba9