### PR TITLE
Fix(conventional-changelog): Allow parsing `BREAKING CHANGES` as comm…

### DIFF
--- a/packages/conventional-changelog-lmc-bitbucket/src/index.js
+++ b/packages/conventional-changelog-lmc-bitbucket/src/index.js
@@ -40,7 +40,7 @@ const writerOpts = {
 
     const transformedCommit = commit;
 
-    if (commit.type === 'BREAKING CHANGE') {
+    if (commit.type === 'BREAKING CHANGE' || commit.type === 'BREAKING CHANGES') {
       transformedCommit.type = 'BREAKING CHANGES';
     } else if (commit.type === 'Feat') {
       transformedCommit.type = 'Features';

--- a/packages/conventional-changelog-lmc-bitbucket/tests/index.test.js
+++ b/packages/conventional-changelog-lmc-bitbucket/tests/index.test.js
@@ -22,6 +22,8 @@ betterThanBefore.setups([
     shell.exec('git init --template=./git-templates');
 
     gitDummyCommit('Chore: first commit');
+    gitDummyCommit('BREAKING CHANGE: Not so compatible change');
+    gitDummyCommit('BREAKING CHANGES: Another big change that break things');
     gitDummyCommit(['Feat: amazing new module', 'BREAKING CHANGE: Not backward compatible.']);
     gitDummyCommit(['Fix(compile): avoid a bug', 'BREAKING CHANGE: The Change is huge.']);
     gitDummyCommit(['Perf(ngOptions): make it faster', ' closes #1, #2']);
@@ -98,6 +100,8 @@ describe('lmc bitbucket preset', () => {
           expect(stringifiedChunk).toInclude('Reverts');
           expect(stringifiedChunk).toInclude('bad commit');
           expect(stringifiedChunk).toInclude('BREAKING CHANGE');
+          expect(stringifiedChunk).toInclude('Not so compatible change');
+          expect(stringifiedChunk).toInclude('Another big change that break things');
 
           // expect(stringifiedChunk).not.toInclude('first commit');
           expect(stringifiedChunk).not.toInclude('feat');

--- a/packages/conventional-changelog-lmc-github/src/writer-opts.js
+++ b/packages/conventional-changelog-lmc-github/src/writer-opts.js
@@ -30,7 +30,7 @@ module.exports = {
 
     const transformedCommit = commit;
 
-    if (commit.type === 'BREAKING CHANGE') {
+    if (commit.type === 'BREAKING CHANGE' || commit.type === 'BREAKING CHANGES') {
       transformedCommit.type = 'BREAKING CHANGES';
     } else if (commit.type === 'Feat') {
       transformedCommit.type = 'Features';

--- a/packages/conventional-changelog-lmc-github/tests/index.test.js
+++ b/packages/conventional-changelog-lmc-github/tests/index.test.js
@@ -23,6 +23,8 @@ betterThanBefore.setups([
     shell.exec('git init --template=./git-templates');
 
     gitDummyCommit('Chore: first commit');
+    gitDummyCommit('BREAKING CHANGE: Not so compatible change');
+    gitDummyCommit('BREAKING CHANGES: Another big change that break things');
     gitDummyCommit(['Feat: amazing new module', 'BREAKING CHANGE: Not backward compatible.']);
     gitDummyCommit(['Fix(compile): avoid a bug', 'BREAKING CHANGE: The Change is huge.']);
     gitDummyCommit(['Perf(ngOptions): make it faster', ' closes #1, #2']);
@@ -48,7 +50,7 @@ betterThanBefore.setups([
     gitDummyCommit(['Chore(deps): bump', 'BREAKING CHANGE: The Change is huge.']);
   },
   function () {
-    gitDummyCommit(['Feat(deps): bump', 'BREAKING CHANGE Also works :)']);
+    gitDummyCommit(['Feat(deps): bump', 'BREAKING CHANGES Also works :)']);
   },
   function () {
     shell.exec('git tag v1.0.0');
@@ -99,6 +101,8 @@ describe('lmc github preset', () => {
           expect(chunk).toInclude('Reverts');
           expect(chunk).toInclude('bad commit');
           expect(chunk).toInclude('BREAKING CHANGE');
+          expect(chunk).toInclude('Not so compatible change');
+          expect(chunk).toInclude('Another big change that break things');
 
           // expect(chunk).not.toInclude('first commit');
           expect(chunk).not.toInclude('feat');


### PR DESCRIPTION
…it type (fixes #52, #54)

  * this was incompatible with commitlint-config where is only `BREAKING
    CHANGES` required
  * we want to be less strict and allow to parse both commit types