### PR TITLE
Fix(commitlint-config): Should depend on more general `conventional-c…

### DIFF
--- a/packages/commitlint-config/index.js
+++ b/packages/commitlint-config/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  parserPreset: '@lmc-eu/conventional-changelog-lmc-bitbucket',
+  parserPreset: '@lmc-eu/conventional-changelog-lmc',
   ignores: [(commit) => commit.includes('[CI-SKIP]')],
   rules: {
     'type-case': [1, 'always', 'pascal-case'],

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "@commitlint/config-conventional": "^16.0.0",
-    "@lmc-eu/conventional-changelog-lmc-bitbucket": "^1.3.7"
+    "@lmc-eu/conventional-changelog-lmc": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,14 +2017,6 @@
     npmlog "^6.0.2"
     write-file-atomic "^3.0.3"
 
-"@lmc-eu/conventional-changelog-lmc-bitbucket@^1.3.7":
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/@lmc-eu/conventional-changelog-lmc-bitbucket/-/conventional-changelog-lmc-bitbucket-1.3.7.tgz#8803092f66485d714af49461617d6e147aea2ba4"
-  integrity sha512-U4k+PY7xNqTAq1KoC2xYchV80gFlXpcjFymh9YMz5ue6gz2M1Pek5DtB0dYoliET5AYV/X6FYlKoPvUkFLKVZw==
-  dependencies:
-    compare-func "^2.0.0"
-    q "^1.5.1"
-
 "@microsoft/fetch-event-source@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz#9ceecc94b49fbaa15666e38ae8587f64acce007d"


### PR DESCRIPTION
…hangelog-lmc` (fixes #46)

  * commitlint only needs parser opts to parse commits
  * more general conventional-changelog-lmc includes only parser and
    writer opts