### PR TITLE
Chore(repo): Disable version decision by conventional commits

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
   "command": {
     "version": {
       "allowBranch": ["release"],
-      "conventionalCommits": true,
+      "conventionalCommits": false,
       "changelogPreset": "./packages/conventional-changelog-lmc-github",
       "push": false,
       "message": "Chore: Release [CI-SKIP]",


### PR DESCRIPTION
  * lerna is using conventional commits to resolve version for each package, eg. https://www.conventionalcommits.org/en/v1.0.0/
  * since we are using our own conventional commits rules which differs slightly from conventional commits (text case), the version resolving do not work correctly
  * for instance breaking changes are not recognized
  * from now on the Lerna will prompt to choose right version for each package