### PR TITLE
Feat(stylelint-config): Allow private SASS variables prefixed with `_`

### DIFF
--- a/packages/stylelint-config/rules/extras.js
+++ b/packages/stylelint-config/rules/extras.js
@@ -11,7 +11,8 @@ module.exports = {
     'selector-nested-pattern': [
       '(^&:)|(^&\\[)|(^&\\.(is\\-|has\\-))',
       {
-        message: 'Only pseudo class selector, attribute selector and combination with state class is allowed',
+        message:
+          'Only pseudo class selector, attribute selector and combination with state class is allowed (selector-nested-pattern)',
       },
     ],
 
@@ -30,8 +31,7 @@ module.exports = {
       },
       {
         message:
-          'Transitioning all properties and absolute background URLs are ' +
-          'not allowed (declaration-property-value-disallowed-list)',
+          'Transitioning all properties and absolute background URLs are not allowed (declaration-property-value-disallowed-list)',
       },
     ],
 

--- a/packages/stylelint-config/rules/stylelint-config-standard-scss-overrides.js
+++ b/packages/stylelint-config/rules/stylelint-config-standard-scss-overrides.js
@@ -8,7 +8,8 @@ module.exports = {
       '(^([A-Z][a-zA-Z0-9]*)((--|__)[a-z][a-zA-Z0-9]*)*$)|(^([a-z][a-z0-9]*)(-[a-z0-9]+)*$)',
       {
         message:
-          'Expected class selector to be in format `MyComponent__myElement`, `MyComponent--modifier` or `kebab-case` for utility classes',
+          'Expected class selector to be in format `MyComponent__myElement`, `MyComponent--modifier` ' +
+          'or `kebab-case` for utility classes (selector-class-pattern)',
       },
     ],
 
@@ -36,6 +37,17 @@ module.exports = {
         except: ['blockless-after-same-name-blockless', 'first-nested'],
         ignore: ['after-comment'],
         ignoreAtRules: ['else'],
+      },
+    ],
+
+    // Allow only kebab-case variables naming. For private variables also allow underscore prefix.
+    // Reason: To allow underscore prefix for private variables.
+    // Docs: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-pattern/README.md
+    'scss/dollar-variable-pattern': [
+      '^(_?[a-z][a-z0-9]*)(-[a-z0-9]+)*$',
+      {
+        message:
+          'Expected variable to be kebab-case. Underscore prefix for private variables is allowed (scss/dollar-variable-pattern)',
       },
     ],
   },


### PR DESCRIPTION
+ Provide rule name at the end of custom stylelint rule message.