### PR TITLE
Feat(stylelint-config): Add missing CSS properties to `CSS properties…

### DIFF
--- a/packages/stylelint-config/rules/properties-order.js
+++ b/packages/stylelint-config/rules/properties-order.js
@@ -15,6 +15,7 @@ module.exports = {
       'bottom',
       'left',
       'z-index',
+      'isolation',
 
       // General appearance
       'appearance',
@@ -61,6 +62,7 @@ module.exports = {
       'align-items',
       'justify-self',
       'justify-content',
+      'justify-items',
       'order',
       'shape-outside',
       'shape-image-threshold',


### PR DESCRIPTION
… order` ruleset