### PR TITLE
Fix(eslint-config-typescript): Fix base module resolving

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -2,7 +2,7 @@ const base = require('@lmc-eu/eslint-config-base');
 const globs = require('@lmc-eu/eslint-config-base/globs');
 
 module.exports = {
-  extends: [...require.resolve('@lmc-eu/eslint-config-base'), 'plugin:@typescript-eslint/recommended'],
+  extends: [require.resolve('@lmc-eu/eslint-config-base'), 'plugin:@typescript-eslint/recommended'],
 
   settings: {
     // Correctly recognize .ts and .d.ts files when checking import paths against the filesystem


### PR DESCRIPTION
How was this supposed to work? (I suppose the module is used somewhere and it works here?)

 `require.resolve` returns string, and applying spread operator makes it spread by individual characters. :thinking: 