### PR TITLE
Feat(eslint-config-base): Add support for Typescript in glob imports

### DIFF
--- a/packages/eslint-config-base/rules/imports.js
+++ b/packages/eslint-config-base/rules/imports.js
@@ -36,18 +36,18 @@ module.exports = {
           'scripts/*', // custom npm scripts
           '**/__tests__/**', // jest pattern
           '**/__mocks__/**', // jest pattern
-          'test.{js,jsx}', // repos with a single test file
-          'test-*.{js,jsx}', // repos with multiple top-level test files
-          '**/*{.,_}{test,spec}.{js,jsx}', // tests where the extension or filename suffix denotes that it is a test
-          '**/jest.config.js', // jest config
-          '**/jest.setup.js', // jest setup
-          '**/vue.config.js', // vue-cli config
-          '**/webpack.config.js', // webpack config
-          '**/webpack.config.*.js', // webpack config
-          '**/rollup.config.js', // rollup config
-          '**/rollup.config.*.js', // rollup config
-          '**/gulpfile.js', // gulp config
-          '**/gulpfile.*.js', // gulp config
+          'test.{js,jsx,ts,tsx}', // repos with a single test file
+          'test-*.{js,jsx,ts,tsx}', // repos with multiple top-level test files
+          '**/*{.,_}{test,spec}.{js,jsx,ts,tsx}', // tests where the extension or filename suffix denotes that it is a test
+          '**/jest.config.{js,ts}', // jest config
+          '**/jest.setup.{js,ts}', // jest setup
+          '**/vue.config.{js,ts}', // vue-cli config
+          '**/webpack.config.{js,ts}', // webpack config
+          '**/webpack.config.*.{js,ts}', // webpack config
+          '**/rollup.config.{js,ts}', // rollup config
+          '**/rollup.config.*.{js,ts}', // rollup config
+          '**/gulpfile.{js,ts}', // gulp config
+          '**/gulpfile.*.{js,ts}', // gulp config
           '**/Gruntfile{,.js}', // grunt config
           '**/protractor.conf.js', // protractor config
           '**/protractor.conf.*.js', // protractor config


### PR DESCRIPTION
  * `import/no-extraneous-dependencies now ignores also Typescript config files when importing from the devDependencies