### PR TITLE
feat(markdownlint)!: drop node 18, move remark-config to alma-oss scope

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import config from '@almacareer/remark-config';
+import config from '@alma-oss/remark-config';
 
 export default {
   ...config,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This monorepo contains shareable configurations for various coding-style/best pr
 | ESLint       | [@lmc-eu/eslint-config-jest](packages/eslint-config-jest)             | [![@lmc-eu/eslint-config-jest][ec-jest-badge]][ec-jest-npm]    |
 | ESLint       | [@lmc-eu/eslint-config-typescript](packages/eslint-config-typescript) | [![@lmc-eu/eslint-config-typescript][ec-ts-badge]][ec-ts-npm]  |
 | Prettier     | [@lmc-eu/prettier-config](packages/prettier-config)                   | [![@lmc-eu/prettier-config][pc-badge]][pc-npm]                 |
-| Remark       | [@almacareer/remark-config](packages/remark-config)                   | [![@almacareer/remark-config][rmc-badge]][rmc-npm]             |
+| Remark       | [@alma-oss/remark-config](packages/remark-config)                     | [![@alma-oss/remark-config][rmc-badge]][rmc-npm]               |
 | Stylelint    | [@almacareer/stylelint-config](packages/stylelint-config)             | [![@almacareer/stylelint-config][slc-badge]][slc-npm]          |
 | Textlint     | [@lmc-eu/textlint-rule-preset-lmc](packages/textlint-rule-preset-lmc) | [![@lmc-eu/textlint-rule-preset-lmc][tlc-badge]][tlc-npm]      |
 
@@ -49,6 +49,6 @@ We got a lot of inspiration from a similar project at [STRV][strv-github]. Thank
 [ec-ts-badge]: https://img.shields.io/npm/v/%40lmc-eu/eslint-config-typescript.svg?style=flat-square
 [tlc-npm]: https://www.npmjs.com/package/@lmc-eu/textlint-rule-preset-lmc
 [tlc-badge]: https://img.shields.io/npm/v/%40lmc-eu/textlint-rule-preset-lmc.svg?style=flat-square
-[rmc-npm]: https://www.npmjs.com/package/@almacareer/remark-config
-[rmc-badge]: https://img.shields.io/npm/v/%40almacareer/remark-config.svg?style=flat-square
+[rmc-npm]: https://www.npmjs.com/package/@alma-oss/remark-config
+[rmc-badge]: https://img.shields.io/npm/v/%40alma-oss/remark-config.svg?style=flat-square
 [strv-github]: https://github.com/strvcom/code-quality-tools

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@alma-oss/prettier-config": "workspace:^",
-    "@almacareer/remark-config": "workspace:^",
+    "@alma-oss/remark-config": "workspace:^",
     "@commitlint/cli": "20.5.0",
     "conventional-changelog-conventionalcommits": "7.0.2",
     "eslint": "9.39.4",

--- a/packages/remark-config/README.md
+++ b/packages/remark-config/README.md
@@ -1,17 +1,17 @@
-# @almacareer/remark-config
+# @alma-oss/remark-config
 
 > Alma Career’s config for [remark-cli][remark-cli-home]
 
 ## Usage
 
 ```sh
-npm i --dev remark-cli @almacareer/remark-config
+npm i --dev remark-cli @alma-oss/remark-config
 ```
 
 Now, create a _.remarkrc.js_ file in your project’s root with the following contents:
 
 ```js
-import config from '@almacareer/remark-config';
+import config from '@alma-oss/remark-config';
 
 export default {
   ...config,

--- a/packages/remark-config/package.json
+++ b/packages/remark-config/package.json
@@ -20,7 +20,9 @@
   },
   "license": "MIT",
   "type": "module",
-  "main": "index.js",
+  "exports": {
+    ".": "./index.js"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/remark-config/package.json
+++ b/packages/remark-config/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/lmc-eu/code-quality-tools.git"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/remark-config/package.json
+++ b/packages/remark-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@almacareer/remark-config",
+  "name": "@alma-oss/remark-config",
   "description": "Alma Career's config for Markdown linting with Remark",
   "version": "0.1.0",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,9 +104,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@almacareer/remark-config@workspace:^, @almacareer/remark-config@workspace:packages/remark-config":
+"@alma-oss/remark-config@workspace:^, @alma-oss/remark-config@workspace:packages/remark-config":
   version: 0.0.0-use.local
-  resolution: "@almacareer/remark-config@workspace:packages/remark-config"
+  resolution: "@alma-oss/remark-config@workspace:packages/remark-config"
   dependencies:
     remark-preset-lint-consistent: "npm:^6.0.0"
     remark-preset-lint-markdown-style-guide: "npm:^6.0.0"
@@ -5336,7 +5336,7 @@ __metadata:
   resolution: "code-quality-tools@workspace:."
   dependencies:
     "@alma-oss/prettier-config": "workspace:^"
-    "@almacareer/remark-config": "workspace:^"
+    "@alma-oss/remark-config": "workspace:^"
     "@commitlint/cli": "npm:20.5.0"
     conventional-changelog-conventionalcommits: "npm:7.0.2"
     eslint: "npm:9.39.4"


### PR DESCRIPTION
## Description

Node.js v18 reaches end-of-life and other packages in this monorepo have already dropped it and moved from the `@almacareer` npm scope to `@alma-oss`; `remark-config` was still on the old scope with a `>=18` engines range. This PR brings it in line: bumps the minimum supported Node.js version to v20 and renames the package to `@alma-oss/remark-config`, updating every internal reference (root `package.json`, `.remarkrc.mjs`, `README.md`, `yarn.lock`).

### Additional context

Both changes are breaking for consumers: they need to bump their Node.js version and update their dependency to `@alma-oss/remark-config`.