### PR TITLE
feat(stylelint)!: drop node 18, move stylelint-config to alma-oss scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This monorepo contains shareable configurations for various coding-style/best pr
 | ESLint       | [@lmc-eu/eslint-config-typescript](packages/eslint-config-typescript) | [![@lmc-eu/eslint-config-typescript][ec-ts-badge]][ec-ts-npm]  |
 | Prettier     | [@lmc-eu/prettier-config](packages/prettier-config)                   | [![@lmc-eu/prettier-config][pc-badge]][pc-npm]                 |
 | Remark       | [@alma-oss/remark-config](packages/remark-config)                     | [![@alma-oss/remark-config][rmc-badge]][rmc-npm]               |
-| Stylelint    | [@almacareer/stylelint-config](packages/stylelint-config)             | [![@almacareer/stylelint-config][slc-badge]][slc-npm]          |
+| Stylelint    | [@alma-oss/stylelint-config](packages/stylelint-config)               | [![@alma-oss/stylelint-config][slc-badge]][slc-npm]            |
 | Textlint     | [@lmc-eu/textlint-rule-preset-lmc](packages/textlint-rule-preset-lmc) | [![@lmc-eu/textlint-rule-preset-lmc][tlc-badge]][tlc-npm]      |
 
 ## License
@@ -35,8 +35,8 @@ We got a lot of inspiration from a similar project at [STRV][strv-github]. Thank
 [pc-badge]: https://img.shields.io/npm/v/%40lmc-eu/prettier-config.svg?style=flat-square
 [clc-npm]: https://www.npmjs.com/package/@alma-oss/commitlint-config
 [clc-badge]: https://img.shields.io/npm/v/%40alma-oss/commitlint-config.svg?style=flat-square
-[slc-npm]: https://www.npmjs.com/package/@almacareer/stylelint-config
-[slc-badge]: https://img.shields.io/npm/v/%40almacareer/stylelint-config.svg?style=flat-square
+[slc-npm]: https://www.npmjs.com/package/@alma-oss/stylelint-config
+[slc-badge]: https://img.shields.io/npm/v/%40alma-oss/stylelint-config.svg?style=flat-square
 [ec-base-npm]: https://www.npmjs.com/package/@lmc-eu/eslint-config-base
 [ec-base-badge]: https://img.shields.io/npm/v/%40lmc-eu/eslint-config-base.svg?style=flat-square
 [ec-gql-npm]: https://www.npmjs.com/package/@lmc-eu/eslint-config-graphql

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -1,8 +1,8 @@
-# `@almacareer/stylelint-config`
+# `@alma-oss/stylelint-config`
 
-[![npm version](https://img.shields.io/npm/v/@almacareer/stylelint-config?label=npm%20package&logo=npm)](https://www.npmjs.org/package/@almacareer/stylelint-config)
-[![Node version](https://img.shields.io/node/v/@almacareer/stylelint-config.svg?style=flat&logo=nodedotjs)](http://nodejs.org/download/)
-[![Stylelint version](https://img.shields.io/npm/dependency-version/@almacareer/stylelint-config/peer/stylelint?logo=stylelint)](https://github.com/stylelint/stylelint)
+[![npm version](https://img.shields.io/npm/v/@alma-oss/stylelint-config?label=npm%20package&logo=npm)](https://www.npmjs.org/package/@alma-oss/stylelint-config)
+[![Node version](https://img.shields.io/node/v/@alma-oss/stylelint-config.svg?style=flat&logo=nodedotjs)](https://nodejs.org/download/)
+[![Stylelint version](https://img.shields.io/npm/dependency-version/@alma-oss/stylelint-config/peer/stylelint?logo=stylelint)](https://github.com/stylelint/stylelint)
 
 > Alma Career’s config for Stylelint
 
@@ -10,10 +10,10 @@
 
 ```bash
 # Yarn:
-yarn add --dev @almacareer/stylelint-config stylelint-prettier
+yarn add --dev @alma-oss/stylelint-config stylelint-prettier
 
 # npm:
-npm install --save-dev @almacareer/stylelint-config stylelint-prettier
+npm install --save-dev @alma-oss/stylelint-config stylelint-prettier
 ```
 
 > We assume you are using Prettier. That’s why we also recommend adding
@@ -29,7 +29,7 @@ This config:
 
 ## Configuration
 
-- **`@almacareer/stylelint-config`**
+- **`@alma-oss/stylelint-config`**
 
 Use this ruleset to configure Stylelint to work with your code.
 
@@ -39,7 +39,7 @@ Use this ruleset to configure Stylelint to work with your code.
 // .stylelintrc.mjs
 
 export default {
-  extends: ['@almacareer/stylelint-config', 'stylelint-prettier/recommended'],
+  extends: ['@alma-oss/stylelint-config', 'stylelint-prettier/recommended'],
 };
 ```
 
@@ -48,7 +48,7 @@ export default {
 
 ```json
 {
-  "extends": ["@almacareer/stylelint-config", "stylelint-prettier/recommended"]
+  "extends": ["@alma-oss/stylelint-config", "stylelint-prettier/recommended"]
 }
 ```
 
@@ -60,7 +60,7 @@ export default {
 ```json
 {
   "stylelint": {
-    "extends": ["@almacareer/stylelint-config", "stylelint-prettier/recommended"]
+    "extends": ["@alma-oss/stylelint-config", "stylelint-prettier/recommended"]
   }
 }
 ```

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -32,7 +32,7 @@
     "directory": "packages/stylelint-config"
   },
   "engines": {
-    "node": "^18.12.0 || >=20"
+    "node": ">=20"
   },
   "scripts": {
     "lint": "yarn lint:css",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -12,7 +12,6 @@
   "author": "Tomáš Litera <tomas.litera@almacareer.com>",
   "license": "MIT",
   "type": "module",
-  "main": "index.js",
   "files": [
     "index.js",
     "rules/extras.js",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@almacareer/stylelint-config",
+  "name": "@alma-oss/stylelint-config",
   "version": "9.1.3",
   "description": "Alma Career's config for Stylelint",
   "keywords": [
@@ -9,7 +9,7 @@
     "career",
     "preset"
   ],
-  "author": "Tomáš Litera <tomas.litera@lmc.eu>",
+  "author": "Tomáš Litera <tomas.litera@almacareer.com>",
   "license": "MIT",
   "type": "module",
   "main": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,9 +114,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@almacareer/stylelint-config@workspace:packages/stylelint-config":
+"@alma-oss/stylelint-config@workspace:packages/stylelint-config":
   version: 0.0.0-use.local
-  resolution: "@almacareer/stylelint-config@workspace:packages/stylelint-config"
+  resolution: "@alma-oss/stylelint-config@workspace:packages/stylelint-config"
   dependencies:
     npm-run-all2: "npm:9.0.3"
     postcss-scss: "npm:^4.0.3"


### PR DESCRIPTION
## Description

Same follow-up as #250, now for `stylelint-config`: Node.js v18 reaches end-of-life and other packages in this monorepo have already dropped it and moved from the `@almacareer` npm scope to `@alma-oss`; `stylelint-config` was still on the old scope with a `^18.12.0 || >=20` engines range and a stale author email domain. This PR brings it in line: bumps the minimum supported Node.js version to v20, renames the package to `@alma-oss/stylelint-config` (also updating the author email to `almacareer.com`, matching the convention used for the other alma-oss packages), and drops the now-redundant `main` field since the package already declares an `exports` map.

### Additional context

Both the Node.js bump and the scope rename are breaking for consumers: they need to bump their Node.js version and update their dependency to `@alma-oss/stylelint-config`.