### PR TITLE
feat(textlint): merge terminology overrides instead of replacing them

### DIFF
--- a/packages/textlint-rule-preset-lmc/README.md
+++ b/packages/textlint-rule-preset-lmc/README.md
@@ -41,6 +41,32 @@ module.exports = {
 
 </details>
 
+## Excluding Terminology Rule Terms
+
+The preset’s `terminology` rule ships with its own curated term list (see [`rules/terminology.js`](rules/terminology.js)) and disables `textlint-rule-terminology`’s built-in defaults. If you only want to drop a few terms from that list, pass an `exclude` array — it’s merged with the preset’s own options, so you keep everything else, including `defaultTerms: false`:
+
+```js
+// .textlintrc.js
+
+'use strict';
+
+module.exports = {
+  rules: {
+    '@lmc-eu/textlint-rule-preset-lmc': {
+      terminology: {
+        exclude: ['ID', 'bug[- ]?fix(es?)', 'build system(s?)'],
+      },
+    },
+  },
+};
+```
+
+Each entry in `exclude` must match a term key exactly as written in the preset’s `terms` list — for a `[pattern, replacement]` pair, that’s the `pattern` string, for instance `'bug[- ]?fix(es?)'`, not a paraphrase of it.
+
+Any other option you pass, including your own `terms`, is merged the same way: that specific key replaces the preset’s default for it, while every key you didn’t specify — such as `defaultTerms: false` — is kept from the preset.
+
+This differs from textlint’s usual behavior for rule config, where a consumer-supplied options object replaces the rule’s config wholesale rather than merging with it. If you were previously relying on a partial override falling back to `textlint-rule-terminology`’s own defaults for anything you didn’t set, that fallback no longer happens — unset keys now come from this preset’s defaults instead.
+
 ## License
 
 See the [LICENSE](LICENSE) file for more information.

--- a/packages/textlint-rule-preset-lmc/__tests__/terminology.test.js
+++ b/packages/textlint-rule-preset-lmc/__tests__/terminology.test.js
@@ -1,0 +1,56 @@
+const assert = require('node:assert/strict');
+const { describe, it } = require('node:test');
+const { TextlintKernel } = require('@textlint/kernel');
+const textPlugin = require('@textlint/textlint-plugin-text').default;
+const preset = require('../index.js');
+
+/**
+ * Lints text with only the preset's terminology rule enabled.
+ *
+ * @param {object|boolean} terminologyOptions rule options passed straight through to the rule
+ *   (`true` enables the rule with the preset's own defaults, matching a real .textlintrc.js)
+ * @param {string} text text to lint
+ * @returns {Promise<string[]>} messages reported by the rule
+ */
+async function lint(terminologyOptions, text) {
+  const kernel = new TextlintKernel();
+  const result = await kernel.lintText(text, {
+    ext: '.txt',
+    plugins: [{ pluginId: 'text', plugin: textPlugin }],
+    rules: [{ ruleId: 'terminology', rule: preset.rules.terminology, options: terminologyOptions }],
+  });
+
+  return result.messages.map((message) => message.message);
+}
+
+describe('terminology rule', () => {
+  it('flags a term from the preset default list', async () => {
+    const messages = await lint(true, 'We use the id field.');
+
+    assert.deepEqual(messages, ['Incorrect usage of the term: “id”, use “ID” instead']);
+  });
+
+  it("does not flag terms from textlint-rule-terminology's own defaults", async () => {
+    const messages = await lint(true, 'We rely on semver and jQuery here.');
+
+    assert.deepEqual(messages, []);
+  });
+
+  it('excludes a plain-string term without losing the rest of the preset defaults', async () => {
+    const messages = await lint({ exclude: ['ID'] }, 'We use the id field and also rely on semver and jQuery here.');
+
+    assert.deepEqual(messages, []);
+  });
+
+  it('excludes a [pattern, replacement] term by matching the pattern string', async () => {
+    const messages = await lint({ exclude: ['build system(s?)'] }, 'We rely on the build systems here.');
+
+    assert.deepEqual(messages, []);
+  });
+
+  it('replaces the preset terms outright when consumer supplies its own terms', async () => {
+    const messages = await lint({ terms: ['banana'] }, 'We use the id field.');
+
+    assert.deepEqual(messages, []);
+  });
+});

--- a/packages/textlint-rule-preset-lmc/index.js
+++ b/packages/textlint-rule-preset-lmc/index.js
@@ -1,9 +1,9 @@
-const terminology = require('textlint-rule-terminology');
 const stopwords = require('textlint-rule-stop-words');
 const misspellings = require('textlint-rule-common-misspellings').default;
 const writegood = require('textlint-rule-write-good').default;
 const titlecase = require('textlint-rule-title-case');
 const apostrophe = require('textlint-rule-apostrophe');
+const terminology = require('./rules/terminology');
 
 module.exports = {
   rules: {
@@ -20,84 +20,7 @@ module.exports = {
   },
 
   rulesConfig: {
-    terminology: {
-      defaultTerms: false,
-      skip: ['Blockquote', 'Header', 'Link', 'Emphasis', 'Strong'],
-      terms: [
-        // Brands
-        'Airbnb',
-        'AVA',
-        'Browsersync',
-        'ESLint',
-        'JavaScript',
-        'Lodash',
-        'Markdown',
-        'Sass',
-        'TypeScript',
-        'UglifyJS',
-        ['JSDocs?', 'JSDoc'],
-        // Official is Node.js and we prefer it
-        ['Node[ .]js', 'Node.js'],
-        ['React[ .]js', 'React'],
-        ['StackOverflow', 'Stack Overflow'],
-        ['HTTP[ /]2(?:\\.0)?', 'HTTP/2'],
-        ['OS X', 'macOS'],
-        ['Mac ?OS', 'macOS'],
-        ['a npm', 'an npm'],
-        'npm',
-        'styled-components',
-        'react-router',
-        'ECMAScript',
-        'Amazon',
-        'Facebook',
-        'AWS',
-        'Heroku',
-        'Netlify',
-        'LMC',
-        'InVision',
-        'Google',
-        'GitHub',
-        'Microsoft',
-
-        // Words and phrases
-
-        // http://stackoverflow.com/questions/1151338/id-or-id-on-user-interface
-        'ID',
-        ["id['’]?s", 'IDs'],
-        ['back[- ]end(\\w*)', 'backend$1'],
-        ['front[- ]end(\\w*)', 'frontend$1'],
-        ['end ?to ?end', 'end-to-end'],
-        ['hot[- ]key', 'hotkey'],
-        ['build system(s?)', 'build tool$1'],
-        ['CLI tool(s?)', 'command line tool$1'],
-        ['web[- ]?site(s?)', 'site$1'],
-        ['repo\\b', 'repository'],
-        ['style-?guide(s?)', 'style guide$1'],
-        // We want to allow writting `changelog` or `change log`
-        // ['change-?log(s?)', 'change log$1'],
-        ['source-?map(s?)', 'source map$1'],
-        ['pre[- ]release(s?)', 'prerelease$1'],
-        ['server ?side', 'server-side'],
-        ['client ?side', 'client-side'],
-        ['filetype(s?)', 'file type$1'],
-        ['auto[- ]?complete', 'autocomplete'],
-        ['auto[- ]?format', 'autoformat'],
-        ['auto[- ]?fix', 'autofix'],
-        ['auto[- ]?fixing', 'autofixing'],
-        ['bug[- ]?fix(es?)', 'bugfix$1'],
-        ['lock[- ]?file(s?)', 'lockfile$1'],
-        ['name[- ]space(s?)', 'namespace$1'],
-        ['tree-?shaking', 'tree shaking'],
-        ['css-?in-?js', 'CSS in JS'],
-        ['higher ?order', 'higher-order'],
-
-        // Starts from a lower case letter in the middle of a sentence
-        ['(\\w+[^.?!]\\)? )internet (?![Ee]xplorer)', '$1internet'],
-        ['Internet Explorer', 'Internet Explorer'],
-        ['(\\w+[^.?!]\\)? )stylelint', '$1Stylelint'],
-        ['(\\w+[^.?!]\\)? )webpack', '$1Webpack'],
-      ],
-    },
+    terminology: true,
     'stop-words': true,
     'common-misspellings': true,
     'write-good': {

--- a/packages/textlint-rule-preset-lmc/package.json
+++ b/packages/textlint-rule-preset-lmc/package.json
@@ -23,6 +23,9 @@
   "engines": {
     "node": "^16 || ^18 || >=20"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "textlint": "^12.2.2",
     "textlint-filter-rule-comments": "^1.2.2",
@@ -32,6 +35,10 @@
     "textlint-rule-terminology": "^3.0.0",
     "textlint-rule-title-case": "^3.0.0",
     "textlint-rule-write-good": "^2.0.0"
+  },
+  "devDependencies": {
+    "@textlint/kernel": "^12.2.2",
+    "@textlint/textlint-plugin-text": "^12.2.2"
   },
   "peerDependencies": {
     "textlint": "^12.2.2"

--- a/packages/textlint-rule-preset-lmc/rules/terminology.js
+++ b/packages/textlint-rule-preset-lmc/rules/terminology.js
@@ -1,0 +1,117 @@
+const terminologyRule = require('textlint-rule-terminology');
+
+const defaultOptions = {
+  defaultTerms: false,
+  skip: ['Blockquote', 'Header', 'Link', 'Emphasis', 'Strong'],
+  terms: [
+    // Brands
+    'Airbnb',
+    'AVA',
+    'Browsersync',
+    'ESLint',
+    'JavaScript',
+    'Lodash',
+    'Markdown',
+    'Sass',
+    'TypeScript',
+    'UglifyJS',
+    ['JSDocs?', 'JSDoc'],
+    // Official is Node.js and we prefer it
+    ['Node[ .]js', 'Node.js'],
+    ['React[ .]js', 'React'],
+    ['StackOverflow', 'Stack Overflow'],
+    ['HTTP[ /]2(?:\\.0)?', 'HTTP/2'],
+    ['OS X', 'macOS'],
+    ['Mac ?OS', 'macOS'],
+    ['a npm', 'an npm'],
+    'npm',
+    'styled-components',
+    'react-router',
+    'ECMAScript',
+    'Amazon',
+    'Facebook',
+    'AWS',
+    'Heroku',
+    'Netlify',
+    'LMC',
+    'InVision',
+    'Google',
+    'GitHub',
+    'Microsoft',
+
+    // Words and phrases
+
+    // http://stackoverflow.com/questions/1151338/id-or-id-on-user-interface
+    'ID',
+    ["id['’]?s", 'IDs'],
+    ['back[- ]end(\\w*)', 'backend$1'],
+    ['front[- ]end(\\w*)', 'frontend$1'],
+    ['end ?to ?end', 'end-to-end'],
+    ['hot[- ]key', 'hotkey'],
+    ['build system(s?)', 'build tool$1'],
+    ['CLI tool(s?)', 'command line tool$1'],
+    ['web[- ]?site(s?)', 'site$1'],
+    ['repo\\b', 'repository'],
+    ['style-?guide(s?)', 'style guide$1'],
+    // We want to allow writing `changelog` or `change log`
+    // ['change-?log(s?)', 'change log$1'],
+    ['source-?map(s?)', 'source map$1'],
+    ['pre[- ]release(s?)', 'prerelease$1'],
+    ['server ?side', 'server-side'],
+    ['client ?side', 'client-side'],
+    ['filetype(s?)', 'file type$1'],
+    ['auto[- ]?complete', 'autocomplete'],
+    ['auto[- ]?format', 'autoformat'],
+    ['auto[- ]?fix', 'autofix'],
+    ['auto[- ]?fixing', 'autofixing'],
+    ['bug[- ]?fix(es?)', 'bugfix$1'],
+    ['lock[- ]?file(s?)', 'lockfile$1'],
+    ['name[- ]space(s?)', 'namespace$1'],
+    ['tree-?shaking', 'tree shaking'],
+    ['css-?in-?js', 'CSS in JS'],
+    ['higher ?order', 'higher-order'],
+
+    // Starts from a lower case letter in the middle of a sentence
+    ['(\\w+[^.?!]\\)? )internet (?![Ee]xplorer)', '$1internet'],
+    ['Internet Explorer', 'Internet Explorer'],
+    ['(\\w+[^.?!]\\)? )stylelint', '$1Stylelint'],
+    ['(\\w+[^.?!]\\)? )webpack', '$1Webpack'],
+  ],
+};
+
+/**
+ * Merges a consumer-supplied options object (typically just `{ exclude: [...] }`) with the
+ * preset's own defaults, instead of letting it replace them wholesale.
+ *
+ * @param {object|boolean} [options] consumer-supplied rule options (`true`, as textlint passes
+ *   when a rule is enabled with no options, is a no-op here since `defaultOptions` still spreads)
+ * @returns {object} merged options
+ */
+function mergeOptions(options = {}) {
+  return { ...defaultOptions, ...options };
+}
+
+/**
+ * @param {object} context textlint rule context
+ * @param {object|boolean} [options] consumer-supplied rule options (`true`, as textlint passes
+ *   when a rule is enabled with no options, is a no-op here since `defaultOptions` still spreads)
+ * @returns {object} textlint rule reporter
+ */
+function terminologyLinter(context, options) {
+  return terminologyRule.linter(context, mergeOptions(options));
+}
+
+/**
+ * @param {object} context textlint rule context
+ * @param {object|boolean} [options] consumer-supplied rule options (`true`, as textlint passes
+ *   when a rule is enabled with no options, is a no-op here since `defaultOptions` still spreads)
+ * @returns {object} textlint rule reporter
+ */
+function terminologyFixer(context, options) {
+  return terminologyRule.fixer(context, mergeOptions(options));
+}
+
+module.exports = {
+  linter: terminologyLinter,
+  fixer: terminologyFixer,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,6 +2220,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lmc-eu/textlint-rule-preset-lmc@workspace:packages/textlint-rule-preset-lmc"
   dependencies:
+    "@textlint/kernel": "npm:^12.2.2"
+    "@textlint/textlint-plugin-text": "npm:^12.2.2"
     textlint: "npm:^12.2.2"
     textlint-filter-rule-comments: "npm:^1.2.2"
     textlint-rule-apostrophe: "npm:^2.0.0"
@@ -3274,7 +3276,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@textlint/kernel@npm:^12.6.1":
+"@textlint/kernel@npm:^12.2.2, @textlint/kernel@npm:^12.6.1":
   version: 12.6.1
   resolution: "@textlint/kernel@npm:12.6.1"
   dependencies:
@@ -3461,7 +3463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@textlint/textlint-plugin-text@npm:^12.6.1":
+"@textlint/textlint-plugin-text@npm:^12.2.2, @textlint/textlint-plugin-text@npm:^12.6.1":
   version: 12.6.1
   resolution: "@textlint/textlint-plugin-text@npm:12.6.1"
   dependencies:


### PR DESCRIPTION
## Description

When a consuming project wants to drop a few terms from the preset's `terminology` rule (e.g. `ID`, `bug-fix(es)`), the only option was copying the entire ~90-line `terms` array into the project's own `.textlintrc.js` — because textlint replaces a rule's config wholesale rather than merging it, passing just `{ exclude: [...] }` silently dropped the preset's `defaultTerms: false` and reintroduced a pile of unrelated default terms (regex, css, semver, jQuery, …).

This wraps `textlint-rule-terminology` in a small preset-owned module (`terminology.js`) that shallow-merges any consumer-supplied options on top of the preset's own defaults before delegating to the real rule, so `{ exclude: [...] }` now works as expected while keeping everything else intact.

### Additional context

- `exclude` entries must match a term's pattern string exactly (not a regex match) — this comes from `textlint-rule-terminology` itself; documented with a corrected example in the README (the issue's own example had two entries that don't match the actual term keys).
- Verified locally via a symlinked fixture: default behavior unchanged, `exclude` silences targeted terms while `defaultTerms: false` still holds, and `terminology.js` is included in the npm package tarball.
- Merge semantics for existing partial overrides change: previously a partial config replaced the preset's terminology options entirely; it now merges on top of the preset's defaults. Worth flagging to consumers in the changelog.

### Related issues

Closes https://github.com/lmc-eu/code-quality-tools/issues/240