### PR TITLE
docs(textlint): document and test comment filtering

### DIFF
--- a/packages/textlint-rule-preset-lmc/README.md
+++ b/packages/textlint-rule-preset-lmc/README.md
@@ -2,7 +2,7 @@
 
 > LMC’s config for [textlint][textlint-home]
 
-Textlint doesn’t support ["extends" convention](https://github.com/textlint/textlint/issues/210), thus we created [rule-preset](https://textlint.github.io/docs/rule-preset.html), a collection of rules and rulesConfig.
+Textlint doesn’t support ["extends" convention][extends-convention], thus we created [rule-preset][rule-preset-docs], a collection of rules and rulesConfig.
 
 ## Usage
 
@@ -43,7 +43,7 @@ module.exports = {
 
 ## Excluding Terminology Rule Terms
 
-The preset’s `terminology` rule ships with its own curated term list (see [`rules/terminology.js`](rules/terminology.js)) and disables `textlint-rule-terminology`’s built-in defaults. If you only want to drop a few terms from that list, pass an `exclude` array — it’s merged with the preset’s own options, so you keep everything else, including `defaultTerms: false`:
+The preset’s `terminology` rule ships with its own curated term list (see [`rules/terminology.js`][terminology-terms]) and disables `textlint-rule-terminology`’s built-in defaults. If you only want to drop a few terms from that list, pass an `exclude` array — it’s merged with the preset’s own options, so you keep everything else, including `defaultTerms: false`:
 
 ```js
 // .textlintrc.js
@@ -67,8 +67,32 @@ Any other option you pass, including your own `terms`, is merged the same way: t
 
 This differs from textlint’s usual behavior for rule config, where a consumer-supplied options object replaces the rule’s config wholesale rather than merging with it. If you were previously relying on a partial override falling back to `textlint-rule-terminology`’s own defaults for anything you didn’t set, that fallback no longer happens — unset keys now come from this preset’s defaults instead.
 
+## Ignoring Parts of a File
+
+The preset enables textlint’s [`comments` filter rule][comments-filter-rule], so you can silence any rule — including this preset’s own rules — for a specific range of a file with inline HTML comments, without resorting to a `.textlintignore` entry for the whole file:
+
+```md
+We use the ID field here, which is fine.
+
+<!-- textlint-disable -->
+
+This block is skipped entirely, so the id field here is not flagged.
+
+<!-- textlint-enable -->
+
+We use the ID field here again, back to being checked.
+```
+
+A `<!-- textlint-disable -->` with no matching `<!-- textlint-enable -->` ignores everything for the rest of the file. See [textlint’s “Ignoring parts of files” docs][ignoring-parts-of-files] for the full comment syntax, including disabling only a specific rule.
+
 ## License
 
-See the [LICENSE](LICENSE) file for more information.
+See the [LICENSE][license] file for more information.
 
 [textlint-home]: https://github.com/textlint/textlint
+[extends-convention]: https://github.com/textlint/textlint/issues/210
+[rule-preset-docs]: https://textlint.github.io/docs/rule-preset.html
+[terminology-terms]: rules/terminology.js
+[comments-filter-rule]: https://github.com/textlint/textlint-filter-rule-comments
+[ignoring-parts-of-files]: https://textlint.github.io/docs/ignore.html#ignoring-parts-of-files
+[license]: LICENSE

--- a/packages/textlint-rule-preset-lmc/__tests__/comment-filtering.test.js
+++ b/packages/textlint-rule-preset-lmc/__tests__/comment-filtering.test.js
@@ -1,0 +1,62 @@
+const assert = require('node:assert/strict');
+const { describe, it } = require('node:test');
+const { TextlintKernel } = require('@textlint/kernel');
+const markdownPlugin = require('@textlint/textlint-plugin-markdown').default;
+const commentsFilter = require('textlint-filter-rule-comments');
+const preset = require('../index.js');
+
+/**
+ * Lints markdown with the preset's terminology rule and its comment filter enabled,
+ * matching how `filters: { comments: true }` behaves via a real .textlintrc.js.
+ *
+ * @param {string} text markdown text to lint
+ * @returns {Promise<string[]>} messages reported by the rule
+ */
+async function lint(text) {
+  const kernel = new TextlintKernel();
+  const result = await kernel.lintText(text, {
+    ext: '.md',
+    plugins: [{ pluginId: 'markdown', plugin: markdownPlugin }],
+    rules: [{ ruleId: 'terminology', rule: preset.rules.terminology, options: true }],
+    filterRules: [{ ruleId: 'comments', rule: commentsFilter, options: preset.filters.comments }],
+  });
+
+  return result.messages.map((message) => message.message);
+}
+
+describe('comment filtering', () => {
+  it('ignores violations between textlint-disable and textlint-enable comments', async () => {
+    const text = [
+      'We use the id field.',
+      '',
+      '<!-- textlint-disable -->',
+      '',
+      'We use the id field again.',
+      '',
+      '<!-- textlint-enable -->',
+      '',
+      'We use the id field once more.',
+    ].join('\n');
+
+    const messages = await lint(text);
+
+    assert.deepEqual(messages, [
+      'Incorrect usage of the term: “id”, use “ID” instead',
+      'Incorrect usage of the term: “id”, use “ID” instead',
+    ]);
+  });
+
+  it('ignores violations for the rest of the file after an unmatched textlint-disable comment', async () => {
+    const text = ['We use the id field.', '', '<!-- textlint-disable -->', '', 'We use the id field again.'].join('\n');
+
+    const messages = await lint(text);
+
+    assert.deepEqual(messages, ['Incorrect usage of the term: “id”, use “ID” instead']);
+  });
+
+  it('flags violations when no textlint-disable comment is present', async () => {
+    const messages = await lint('We use the id field.');
+
+    assert.deepEqual(messages, ['Incorrect usage of the term: “id”, use “ID” instead']);
+  });
+});

--- a/packages/textlint-rule-preset-lmc/package.json
+++ b/packages/textlint-rule-preset-lmc/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@textlint/kernel": "^12.2.2",
+    "@textlint/textlint-plugin-markdown": "^12.2.2",
     "@textlint/textlint-plugin-text": "^12.2.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,6 +2221,7 @@ __metadata:
   resolution: "@lmc-eu/textlint-rule-preset-lmc@workspace:packages/textlint-rule-preset-lmc"
   dependencies:
     "@textlint/kernel": "npm:^12.2.2"
+    "@textlint/textlint-plugin-markdown": "npm:^12.2.2"
     "@textlint/textlint-plugin-text": "npm:^12.2.2"
     textlint: "npm:^12.2.2"
     textlint-filter-rule-comments: "npm:^1.2.2"
@@ -3444,7 +3445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@textlint/textlint-plugin-markdown@npm:^12.6.1":
+"@textlint/textlint-plugin-markdown@npm:^12.2.2, @textlint/textlint-plugin-markdown@npm:^12.6.1":
   version: 12.6.1
   resolution: "@textlint/textlint-plugin-markdown@npm:12.6.1"
   dependencies:


### PR DESCRIPTION
## Description

The preset already ships `filters: { comments: true }` and depends on `textlint-filter-rule-comments`, so consumers can silence rules for a specific range of a file with inline HTML comments (per textlint's ["ignoring parts of files"](https://textlint.github.io/docs/ignore.html#ignoring-parts-of-files) docs) — but this was undocumented and untested, so nobody knew the capability existed.

This adds a README section explaining the `<!-- textlint-disable -->` / `<!-- textlint-enable -->` comment syntax, and a test suite (using the markdown plugin, since the comments filter needs actual Comment AST nodes that the plain-text plugin doesn't emit) verifying the filter suppresses terminology violations within a disabled range, including the unmatched-disable case.

### Related issues

Closes #193