### PR TITLE
feat(browserslist)!: migrate to alma-oss scope and drop node <20 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This monorepo contains shareable configurations for various coding-style/best pr
 
 | Tool         | Package                                                               | Version                                                        |
 | ------------ | --------------------------------------------------------------------- | -------------------------------------------------------------- |
-| Browserslist | [@lmc-eu/browserslist-config](packages/browserslist-config)           | [![@lmc-eu/browserslist-config][blc-badge]][blc-npm]           |
+| Browserslist | [@alma-oss/browserslist-config](packages/browserslist-config)         | [![@alma-oss/browserslist-config][blc-badge]][blc-npm]         |
 | Commitlint   | [@alma-oss/commitlint-config](packages/commitlint-config)             | [![@alma-oss/commitlint-config][clc-badge]][clc-npm]           |
 | ESLint       | [@lmc-eu/eslint-config-base](packages/eslint-config-base)             | [![@lmc-eu/eslint-config-base][ec-base-badge]][ec-base-npm]    |
 | ESLint       | [@lmc-eu/eslint-config-graphql](packages/eslint-config-graphql)       | [![@lmc-eu/eslint-config-graphql][ec-gql-badge]][ec-gql-npm]   |
@@ -29,8 +29,8 @@ See the [LICENSE](LICENSE) file for information.
 We got a lot of inspiration from a similar project at [STRV][strv-github]. Thank you very much ❤️!
 
 [alma-home]: https://www.almacareer.com
-[blc-npm]: https://npmjs.org/package/%40lmc-eu/browserslist-config
-[blc-badge]: https://img.shields.io/npm/v/%40lmc-eu/browserslist-config.svg?style=flat-square
+[blc-npm]: https://npmjs.org/package/%40alma-oss/browserslist-config
+[blc-badge]: https://img.shields.io/npm/v/%40alma-oss/browserslist-config.svg?style=flat-square
 [pc-npm]: https://www.npmjs.com/package/@lmc-eu/prettier-config
 [pc-badge]: https://img.shields.io/npm/v/%40lmc-eu/prettier-config.svg?style=flat-square
 [clc-npm]: https://www.npmjs.com/package/@alma-oss/commitlint-config

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,15 +1,15 @@
-# `@lmc-eu/browserslist-config`
+# `@alma-oss/browserslist-config`
 
-> LMC’s config for Browserslist
+> Alma Career’s config for Browserslist
 
 ## Installation
 
 ```bash
 # Yarn:
-yarn add --dev @lmc-eu/browserslist-config
+yarn add --dev @alma-oss/browserslist-config
 
 # npm:
-npm install --save-dev @lmc-eu/browserslist-config
+npm install --save-dev @alma-oss/browserslist-config
 ```
 
 ## Usage
@@ -17,14 +17,14 @@ npm install --save-dev @lmc-eu/browserslist-config
 Add this to `.browserslistrc` file:
 
 ```txt
-extends @lmc-eu/browserslist-config
+extends @alma-oss/browserslist-config
 ```
 
 Alternatively, add this to your `package.json` file:
 
 ```json
 "browserslist": [
-  "extends @lmc-eu/browserslist-config"
+  "extends @alma-oss/browserslist-config"
 ]
 ```
 
@@ -33,7 +33,7 @@ Alternatively, add this to your `package.json` file:
 To support Internet Explorer (or any other browser):
 
 ```txt
-extends @lmc-eu/browserslist-config
+extends @alma-oss/browserslist-config
 
 ie # sorry!
 ```
@@ -65,7 +65,7 @@ your `.browserslistrc` (or `package.json`, wherever you store your config):
 As mentioned in the stats file in your Browserslist configuration:
 
 ```txt
-extends @lmc-eu/browserslist-config
+extends @alma-oss/browserslist-config
 
 > 0.5% in my stats
 ```

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -19,6 +19,6 @@
     "directory": "packages/browserslist-config"
   },
   "engines": {
-    "node": "^16 || ^18 || >=20"
+    "node": ">=20"
   }
 }

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@lmc-eu/browserslist-config",
+  "name": "@alma-oss/browserslist-config",
   "version": "2.0.1",
-  "description": "LMC's config for Browserslist",
+  "description": "Alma Career's config for Browserslist",
   "keywords": [
     "browserslist",
     "browserslist-config",
-    "lmc"
+    "alma"
   ],
   "author": "Adam Kudrna <adam.kudrna@lmc.eu>",
   "license": "BSD-3-Clause",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,12 @@ __metadata:
   version: 8
   cacheKey: 10
 
+"@alma-oss/browserslist-config@workspace:packages/browserslist-config":
+  version: 0.0.0-use.local
+  resolution: "@alma-oss/browserslist-config@workspace:packages/browserslist-config"
+  languageName: unknown
+  linkType: soft
+
 "@alma-oss/commitlint-config@workspace:packages/commitlint-config":
   version: 0.0.0-use.local
   resolution: "@alma-oss/commitlint-config@workspace:packages/commitlint-config"
@@ -2196,12 +2202,6 @@ __metadata:
   checksum: 10/e3b2cb1377863342acedd5ff785af3e69269bee9b44707c617d1c8bc14eeb5ac763159d6455903ffe92f143c2238e1e783c4f113f9c8910eacccf172894472da
   languageName: node
   linkType: hard
-
-"@lmc-eu/browserslist-config@workspace:packages/browserslist-config":
-  version: 0.0.0-use.local
-  resolution: "@lmc-eu/browserslist-config@workspace:packages/browserslist-config"
-  languageName: unknown
-  linkType: soft
 
 "@lmc-eu/eslint-config-base@npm:^3.1.3":
   version: 3.1.3


### PR DESCRIPTION
## Description

The browserslist-config package was the last straggler still published under the old `@lmc-eu` npm scope and supporting Node.js 16/18, while every other package in this monorepo had already moved to `@alma-oss` and dropped support for Node.js below 20. This PR brings it in line: renames the package to `@alma-oss/browserslist-config` (README and lockfile updated accordingly) and raises its `engines.node` requirement to `>=20`.

### Additional context

Both changes are breaking and are split into two separate commits (scope rename, then engine bump) so each can be reviewed and reverted independently. A related change to also update the package license to MIT was intentionally left out of this PR — that will happen once the entire repo is migrated to MIT in one pass.

### Related issues

_None._