### PR TITLE
feat(browserslist)!: change license to MIT

### DIFF
--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -8,7 +8,7 @@
     "alma"
   ],
   "author": "Adam Kudrna <adam.kudrna@lmc.eu>",
-  "license": "BSD-3-Clause",
+  "license": "MIT",
   "main": "index.js",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Description

browserslist-config was the last package still declaring `BSD-3-Clause` in its `package.json` — every other already-migrated package (commitlint-config, eslint-config-base, stylelint-config, etc.) declares `MIT`. This PR brings its declared license field in line with the rest.

### Additional context

This only updates the `license` field in `packages/browserslist-config/package.json`. The repo-wide `LICENSE` file itself stays `BSD-3-Clause` until the entire monorepo is migrated in one pass.

### Related issues

_None._